### PR TITLE
Add optional option_focus attribute

### DIFF
--- a/CTkMessagebox/__init__.py
+++ b/CTkMessagebox/__init__.py
@@ -5,7 +5,7 @@ This is a modern messagebox made with customtkinter.
 Homepage: https://github.com/Akascape/CTkMessagebox
 """
 
-__version__ = '2.2'
+__version__ = '2.3'
 
 from .ctkmessagebox import CTkMessagebox
 

--- a/CTkMessagebox/ctkmessagebox.py
+++ b/CTkMessagebox/ctkmessagebox.py
@@ -1,7 +1,7 @@
 """
 CustomTkinter Messagebox
 Author: Akash Bora
-Version: 2.2
+Version: 2.3
 """
 
 import customtkinter
@@ -53,8 +53,10 @@ class CTkMessagebox(customtkinter.CTkToplevel):
                  option_focus: Literal[1, 2, 3] = None):
         
         super().__init__()
-
+        
+        
         self.master_window = master
+     
         self.width = 250 if width<250 else width
         self.height = 150 if height<150 else  height
             
@@ -74,7 +76,7 @@ class CTkMessagebox(customtkinter.CTkToplevel):
         if self.fade:
             self.fade = 20 if self.fade<20 else self.fade
             self.attributes("-alpha", 0)
-            
+        
         if not header:
             self.overrideredirect(1)
     
@@ -97,6 +99,7 @@ class CTkMessagebox(customtkinter.CTkToplevel):
             default_cancel_button = "cross"
 
         self.lift()
+        
         self.config(background=self.transparent_color)
         self.protocol("WM_DELETE_WINDOW", self.button_event)
         self.grid_columnconfigure(0, weight=1)
@@ -236,16 +239,16 @@ class CTkMessagebox(customtkinter.CTkToplevel):
         
         self.button_1.grid(row=2, column=3, sticky="news", padx=(0,10), pady=10)
 
-        if option_2:
-            self.option_text_2 = option_2      
+        self.option_text_2 = option_2 
+        if option_2:     
             self.button_2 = customtkinter.CTkButton(self.frame_top, text=self.option_text_2, fg_color=self.button_color[1],
                                                     width=self.button_width, font=self.font, text_color=self.bt_text_color,
                                                     hover_color=self.bt_hv_color, height=self.button_height,
                                                     command=lambda: self.button_event(self.option_text_2))
             self.button_2.grid(row=2, column=2, sticky="news", padx=10, pady=10)
-            
+
+        self.option_text_3 = option_3
         if option_3:
-            self.option_text_3 = option_3
             self.button_3 = customtkinter.CTkButton(self.frame_top, text=self.option_text_3, fg_color=self.button_color[2],
                                                     width=self.button_width, font=self.font, text_color=self.bt_text_color,
                                                     hover_color=self.bt_hv_color, height=self.button_height,
@@ -262,14 +265,62 @@ class CTkMessagebox(customtkinter.CTkToplevel):
             
         if self.fade:
             self.fade_in()
-
-        if option_focus:
-            selected_button = getattr(self, "button_"+str(option_focus))
-            selected_button.focus()
-            selected_button.configure(border_color=self.bt_hv_color, border_width=2)
-            selected_option = getattr(self, "option_text_"+str(option_focus))
-            selected_button.bind("<Return>", lambda event: self.button_event(selected_option))
             
+        if option_focus:
+            self.option_focus = option_focus
+            self.focus_button(self.option_focus)
+        else:
+            if not self.option_text_2 and not self.option_text_3:
+                self.button_1.focus()
+                self.button_1.bind("<Return>", lambda event: self.button_event(self.option_text_1))
+ 
+        self.bind("<Escape>", lambda e: self.button_event())
+        
+    def focus_button(self, option_focus):
+        try:
+            self.selected_button = getattr(self, "button_"+str(option_focus))
+            self.selected_button.focus()
+            self.selected_button.configure(border_color=self.bt_hv_color, border_width=3)
+            self.selected_option = getattr(self, "option_text_"+str(option_focus))
+            self.selected_button.bind("<Return>", lambda event: self.button_event(self.selected_option))
+        except AttributeError:
+            return
+        
+        self.bind("<Left>", lambda e: self.change_left())
+        self.bind("<Right>", lambda e: self.change_right())
+        
+    def change_left(self):
+        if self.option_focus==3:
+            return
+        
+        self.selected_button.unbind("<Return>")
+        self.selected_button.configure(border_width=0)
+    
+        if self.option_focus==1:
+            if self.option_text_2:
+                self.option_focus = 2
+        
+        elif self.option_focus==2:
+            if self.option_text_3:
+                self.option_focus = 3
+  
+        self.focus_button(self.option_focus)
+        
+    def change_right(self):
+        if self.option_focus==1:
+            return
+        
+        self.selected_button.unbind("<Return>")
+        self.selected_button.configure(border_width=0)
+
+        if self.option_focus==2:
+            self.option_focus = 1
+
+        elif self.option_focus==3:
+            self.option_focus = 2
+                
+        self.focus_button(self.option_focus)
+    
     def load_icon(self, icon, icon_size):
         if icon not in self.ICONS or self.ICONS[icon] is None:
             if icon in ["check", "cancel", "info", "question", "warning"]:

--- a/CTkMessagebox/ctkmessagebox.py
+++ b/CTkMessagebox/ctkmessagebox.py
@@ -9,6 +9,7 @@ from PIL import Image
 import os
 import sys
 import time
+from typing import Literal
 
 class CTkMessagebox(customtkinter.CTkToplevel):
     ICONS = {
@@ -48,7 +49,8 @@ class CTkMessagebox(customtkinter.CTkToplevel):
                  font: tuple = None,
                  header: bool = False,
                  topmost: bool = True,
-                 fade_in_duration: int = 0):
+                 fade_in_duration: int = 0,
+                 option_focus: Literal[1, 2, 3] = None):
         
         super().__init__()
 
@@ -260,6 +262,13 @@ class CTkMessagebox(customtkinter.CTkToplevel):
             
         if self.fade:
             self.fade_in()
+
+        if option_focus:
+            selected_button = getattr(self, "button_"+str(option_focus))
+            selected_button.focus()
+            selected_button.configure(border_color=self.bt_hv_color, border_width=2)
+            selected_option = getattr(self, "option_text_"+str(option_focus))
+            selected_button.bind("<Return>", lambda event: self.button_event(selected_option))
             
     def load_icon(self, icon, icon_size):
         if icon not in self.ICONS or self.ICONS[icon] is None:

--- a/README.md
+++ b/README.md
@@ -148,7 +148,9 @@ app.mainloop()
   | _font_ | font of the messagebox text (tuple) |
   | _header_ | add the original header back if you don't like **overrideredirect** (bool) |
   | _topmost_ | disable the topmost window outside the app (bool) |
+  | _focus_option_ | select an option by default when `Enter` key is pressed |
   | **_fade_in_duration_** | enable a fade-in and fade-out animation (int, default is 0)  |
+  
 
 </div>
 


### PR DESCRIPTION
While working on my application which utilizes CTkMessagebox I had a list of reports with an option to delete each of them. Each deletion was to be confirmed by a CTkMessagebox button click. However, I found the process a bit tedious. Having a default focus for one of the buttons seemed like a good idea. I could then press enter key to confirm deletion without a mouse click.

I thought that this might be a good addition as an optional parameter that can be passed while creating new instance of CTkMessageBox. This parameter could take a number representing the option that should be focused with None as default - but possibly could use the first option as a default choice. I also added a width-2 border to the default focused button for better UX.

I believe that this enhancement aligns with the goals of the project and will benefit both existing and future users. I am open to and look forward to your feedback or suggestions.